### PR TITLE
fix dependencies in build.gradle

### DIFF
--- a/LDIFGenerator/build.gradle
+++ b/LDIFGenerator/build.gradle
@@ -2,11 +2,17 @@ plugins {
     id 'application'
 }
 
-mainClassName = "com.willeke.LDIFGenerator"
+mainClassName = "com.willeke.ldap.ldif.LDIFGenerator"
 executableDir = ""
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
-    compile deps.log4j
+  compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.1'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.1'
+  compile group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.1'
 }
 
 distributions {


### PR DESCRIPTION
- Built successfully using PC with Maven and Gradle installed using `gradle build`
- Implements fix suggested in https://github.com/jwilleke/LDIFGenerator/issues/6